### PR TITLE
Set different agency ids for feed_with_wrong_stops_order and feed_with_multiple_shape_projections.

### DIFF
--- a/feed_with_wrong_stops_order/agency.txt
+++ b/feed_with_wrong_stops_order/agency.txt
@@ -1,2 +1,2 @@
 agency_id,agency_url,agency_lang,agency_name,agency_phone,agency_timezone,agency_fare_url
-1554,http://www.avon.org/2083/Transit,en,Avon Transit,(970) 748-4120,America/Denver,
+1555,http://www.avon.org/2083/Transit,en,Avon Transit,(970) 748-4120,America/Denver,

--- a/feed_with_wrong_stops_order/fare_attributes.txt
+++ b/feed_with_wrong_stops_order/fare_attributes.txt
@@ -1,2 +1,2 @@
 agency_id,fare_id,price,currency_type,payment_method,transfers,transfer_duration
-1554,3733,0.00,USD,0,,0
+1555,3733,0.00,USD,0,,0

--- a/feed_with_wrong_stops_order/routes.txt
+++ b/feed_with_wrong_stops_order/routes.txt
@@ -1,2 +1,2 @@
 agency_id,route_id,route_short_name,route_long_name,route_desc,route_type,route_url,route_color,route_text_color,route_sort_order,min_headway_minutes,eligibility_restricted,continuous_pickup,continuous_drop_off
-1554,15141,Red,Avon East,,3,,ff0000,000000,1,30,0,1,1
+1555,15141,Red,Avon East,,3,,ff0000,000000,1,30,0,1,1


### PR DESCRIPTION
Чтобы в интеграционных тестах не игнорировались данные от агентства которое уже было обработано.